### PR TITLE
adding support for more digest methods

### DIFF
--- a/lib/signed_xml/digest_method_resolution.rb
+++ b/lib/signed_xml/digest_method_resolution.rb
@@ -5,9 +5,12 @@ module SignedXml
     include OpenSSL
 
     def new_digester_for_id(id)
+      id = id && id =~ /sha(.*?)$/i && $1.to_i
       case id
-      when "http://www.w3.org/2000/09/xmldsig#sha1","http://www.w3.org/2000/09/xmldsig#rsa-sha1"
-        Digest::SHA1.new
+      when 256 then OpenSSL::Digest::SHA256.new
+      when 384 then OpenSSL::Digest::SHA384.new
+      when 512 then OpenSSL::Digest::SHA512.new        
+      when 1   then OpenSSL::Digest::SHA1.new
       else
         raise ArgumentError, "unknown digest method #{id}"
       end

--- a/lib/signed_xml/version.rb
+++ b/lib/signed_xml/version.rb
@@ -1,3 +1,3 @@
 module SignedXml
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
I had a signed xml with a digest method http://www.w3.org/2001/04/xmlenc#sha256 and there is no support for it in SignedXml::DigestMethodResolution. 

I added support for SHA256, SHA384, SHA512 and SHA1 using an implementation I found in https://github.com/onelogin/ruby-saml 
