### PR TITLE
Add support for SHA256, which is what the Windows Phone 8 Store uses

### DIFF
--- a/lib/signed_xml/digest_method_resolution.rb
+++ b/lib/signed_xml/digest_method_resolution.rb
@@ -6,6 +6,8 @@ module SignedXml
 
     def new_digester_for_id(id)
       case id
+      when "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256","http://www.w3.org/2001/04/xmlenc#sha256"
+        Digest::SHA256.new
       when "http://www.w3.org/2000/09/xmldsig#sha1","http://www.w3.org/2000/09/xmldsig#rsa-sha1"
         Digest::SHA1.new
       else


### PR DESCRIPTION
I was using your library to verify receipts from the Windows Phone 8 store, and they used a more modern digest (SHA256) so I added support for that in your library. 
